### PR TITLE
feat: add basic club view with placeholder team view. Create service …

### DIFF
--- a/backend/src/main/java/com/scottlogic/GMSv2/jpa/AgeRange.java
+++ b/backend/src/main/java/com/scottlogic/GMSv2/jpa/AgeRange.java
@@ -1,0 +1,7 @@
+package com.scottlogic.GMSv2.jpa;
+
+public enum AgeRange {
+    YOUNG,
+    OLD,
+    SKELETON
+}

--- a/backend/src/main/java/com/scottlogic/GMSv2/jpa/Club.java
+++ b/backend/src/main/java/com/scottlogic/GMSv2/jpa/Club.java
@@ -14,7 +14,8 @@ public class Club {
   @Column(columnDefinition = "BINARY(16)")
   private UUID id;
   private String name;
-  private String adress;
+  private String address;
+  @Column(name = "SHORTNAME")
   private String shortName;
   //@OneToMany(mappedBy = "club")
   //private List<Team> teams;
@@ -30,8 +31,8 @@ public class Club {
     return name;
   }
 
-  public String getAdress() {
-    return adress;
+  public String getAddress() {
+    return address;
   }
 
   public String getShortName() {
@@ -46,8 +47,8 @@ public class Club {
     this.name = name;
   }
 
-  public void setAdress(String adress) {
-    this.adress = adress;
+  public void setAddress(String address) {
+    this.address = address;
   }
 
   public void setShortName(String shortName) {

--- a/backend/src/main/java/com/scottlogic/GMSv2/jpa/Gender.java
+++ b/backend/src/main/java/com/scottlogic/GMSv2/jpa/Gender.java
@@ -1,0 +1,6 @@
+package com.scottlogic.GMSv2.jpa;
+
+public enum Gender {
+    YETI,
+    NOT_YETI
+}

--- a/backend/src/main/java/com/scottlogic/GMSv2/jpa/League.java
+++ b/backend/src/main/java/com/scottlogic/GMSv2/jpa/League.java
@@ -1,0 +1,7 @@
+package com.scottlogic.GMSv2.jpa;
+
+public enum League {
+    LEAGUE_ONE,
+    LEAGUE_TWO,
+    BAD
+}

--- a/backend/src/main/java/com/scottlogic/GMSv2/jpa/Team.java
+++ b/backend/src/main/java/com/scottlogic/GMSv2/jpa/Team.java
@@ -15,8 +15,9 @@ public class Team {
   private UUID id;
   @Column
   private String name;
-  private String address;
-  private String shortName;
+  private League league;
+  private Gender gender;
+  private AgeRange ageRange;
   @Column(name = "CLUBID")
   private UUID clubId;
 
@@ -31,14 +32,6 @@ public class Team {
     return name;
   }
 
-  public String getAddress() {
-    return address;
-  }
-
-  public String getShortName() {
-    return shortName;
-  }
-
   public void setId(UUID id) {
     this.id = id;
   }
@@ -47,18 +40,35 @@ public class Team {
     this.name = name;
   }
 
-  public void setAddress(String address) {
-    this.address = address;
-  }
-
-  public void setShortName(String shortName) {
-    this.shortName = shortName;
-  }
   public void setClubId(UUID clubId) {
     this.clubId = clubId;
   }
 
   public UUID getClubId() {
     return this.clubId;
+  }
+
+  public League getLeague() {
+    return league;
+  }
+
+  public void setLeague(League league) {
+    this.league = league;
+  }
+
+  public Gender getGender() {
+    return gender;
+  }
+
+  public void setGender(Gender gender) {
+    this.gender = gender;
+  }
+
+  public AgeRange getAgeRange() {
+    return ageRange;
+  }
+
+  public void setAgeRange(AgeRange ageRange) {
+    this.ageRange = ageRange;
   }
 }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,7 +1,7 @@
-INSERT INTO club (id, name) VALUES (1, 'Club 1');
-INSERT INTO club (id, name) VALUES (2, 'Club 2');
-INSERT INTO club (id, name) VALUES (3, 'Club 3');
-INSERT INTO club (id, name) VALUES (4, 'Club 4');
+INSERT INTO club (id, name, address, shortName) VALUES (1, 'Firebrands', 'Longwood, Clevedon Road, Failand, Bristol BS8 3TL', 'FHC');
+INSERT INTO club (id, name, address, shortName) VALUES (2, 'Bristol City', 'Ashton Rd, Bristol BS3 2EJ', 'BCFC');
+INSERT INTO club (id, name, address, shortName) VALUES (3, 'Liverpool Football Club', 'Ashton Rd, Bristol BS3 2EJ', 'LFC');
+INSERT INTO club (id, name, address, shortName) VALUES (4, 'Beeston Hockey Club', 'Highfields Park, University Blvd, Nottingham NG7 2PS', 'BHC');
 INSERT INTO club (id, name) VALUES (5, 'Club 5');
 INSERT INTO team (id, name, clubId) VALUES (1, 'Team Amazing', 1);
 INSERT INTO team (id, name, clubId) VALUES (2, 'Matt Team 1', 1);

--- a/front-end/src/app/app.module.ts
+++ b/front-end/src/app/app.module.ts
@@ -10,20 +10,23 @@ import { AgGridModule } from 'ag-grid-angular';
 import { ClubsComponent } from './clubs/clubs.component';
 import { ClubComponent } from './club/club.component';
 import { LinkRendererComponent } from './cell-renderers/link-cell/link-cell.component';
+import { TeamComponent } from './team/team.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     ClubsComponent,
     ClubComponent,
-    LinkRendererComponent
+    LinkRendererComponent,
+    TeamComponent
   ],
   imports: [
     BrowserModule,
     HttpClientModule,
     RouterModule.forRoot([
       { path: 'clubs', component: ClubsComponent },
-      { path: 'clubs/:clubName', component: ClubComponent }
+      { path: 'clubs/:clubName', component: ClubComponent },
+      { path: 'teams/:teamName', component: TeamComponent }
     ]),
     BrowserAnimationsModule,
     FormsModule,

--- a/front-end/src/app/club-service/club.service.spec.ts
+++ b/front-end/src/app/club-service/club.service.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ClubService } from './club.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('ClubService', () => {
+  let service: ClubService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ]});
+    service = TestBed.inject(ClubService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/front-end/src/app/club-service/club.service.ts
+++ b/front-end/src/app/club-service/club.service.ts
@@ -1,0 +1,26 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Club } from '../types/Club';
+import { Team } from '../types/Team';
+import { Observable, map, of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ClubService {
+  host = 'http://localhost:8080';
+
+  constructor(private http: HttpClient) { }
+
+  public getTeams(): Observable<Team[]> {
+    return this.http.get<Team[]>(`${this.host}/teams/`);
+  }
+
+  public getTeamsInClub(club: Club): Observable<Team[]> {
+    return this.http.get<Team[]>(`${this.host}/teams?clubId=${club.id}`);
+  }
+
+  public getClubs(): Observable<Club[]> {
+    return this.http.get<Club[]>(`${this.host}/clubs/`);
+  }
+}

--- a/front-end/src/app/club/club.component.html
+++ b/front-end/src/app/club/club.component.html
@@ -1,1 +1,13 @@
-<p>club works!</p>
+<div *ngIf="club">
+  {{club.name}}
+</div>
+<ag-grid-angular
+   style="width: 100%; height: 100%"
+   class="ag-theme-alpine"
+   [columnDefs]="columnDefs"
+   [defaultColDef]="defaultColDef"
+   [rowData]="rowData$ | async"
+   [rowSelection]="'multiple'"
+   [animateRows]="true"
+   (gridReady)="onGridReady()"
+ ></ag-grid-angular>

--- a/front-end/src/app/club/club.component.spec.ts
+++ b/front-end/src/app/club/club.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ClubComponent } from './club.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AgGridModule } from 'ag-grid-angular';
 
 describe('ClubComponent', () => {
   let component: ClubComponent;
@@ -8,6 +11,11 @@ describe('ClubComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        AgGridModule
+      ],
       declarations: [ ClubComponent ]
     })
     .compileComponents();

--- a/front-end/src/app/club/club.component.ts
+++ b/front-end/src/app/club/club.component.ts
@@ -1,4 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { AgGridAngular } from 'ag-grid-angular';
+import { ColDef } from 'ag-grid-community';
+import { Observable, of } from 'rxjs';
+
+import { Team } from '../types/Team';
+import { Club } from '../types/Club';
+import { ClubService } from '../club-service/club.service';
+import { ActivatedRoute } from '@angular/router';
+import { LinkRendererComponent } from '../cell-renderers/link-cell/link-cell.component';
 
 @Component({
   selector: 'app-club',
@@ -6,5 +15,30 @@ import { Component } from '@angular/core';
   styleUrls: ['./club.component.css']
 })
 export class ClubComponent {
+  club: Club | undefined;
+  teams: Team[] = [];
+  rowData$: Observable<Team[]> = of();
+  @ViewChild(AgGridAngular) agGrid!: AgGridAngular;
 
+  constructor(private clubService: ClubService, private route: ActivatedRoute) {}
+  
+  columnDefs: ColDef[] = [
+    { field: 'name', cellRenderer: LinkRendererComponent, cellRendererParams: { inRouterLink: '/teams' } },
+    { field: 'address'},
+    { field: 'shortName' }
+  ];
+
+  defaultColDef: ColDef = {
+    sortable: true,
+    filter: true,
+  };
+
+  onGridReady() {
+    this.clubService.getClubs().subscribe((clubs) => {
+      this.club = clubs.find(club => club.name === this.route.snapshot.paramMap.get('clubName'));
+      if (this.club) {
+        this.rowData$ = this.clubService.getTeamsInClub(this.club);
+      }
+    });
+  }
 }

--- a/front-end/src/app/club/club.component.ts
+++ b/front-end/src/app/club/club.component.ts
@@ -24,8 +24,9 @@ export class ClubComponent {
   
   columnDefs: ColDef[] = [
     { field: 'name', cellRenderer: LinkRendererComponent, cellRendererParams: { inRouterLink: '/teams' } },
-    { field: 'address'},
-    { field: 'shortName' }
+    { field: 'league'},
+    { field: 'gender' },
+    { field: 'age' }
   ];
 
   defaultColDef: ColDef = {

--- a/front-end/src/app/clubs/clubs.component.ts
+++ b/front-end/src/app/clubs/clubs.component.ts
@@ -3,8 +3,8 @@ import { Component, ViewChild } from '@angular/core';
 import { AgGridAngular } from 'ag-grid-angular';
 import { CellClickedEvent, ColDef, GridReadyEvent } from 'ag-grid-community';
 import { Observable } from 'rxjs';
-import data from './sample-clubs.json';
 import { LinkRendererComponent } from '../cell-renderers/link-cell/link-cell.component';
+import { ClubService } from '../club-service/club.service';
 
 @Component({
   selector: 'app-clubs',
@@ -27,13 +27,10 @@ export class ClubsComponent {
 
   @ViewChild(AgGridAngular) agGrid!: AgGridAngular;
 
-  constructor(private http: HttpClient) {}
+  constructor(private clubService: ClubService) {}
 
   onGridReady(params: GridReadyEvent) {
-    this.rowData$ = new Observable(observer => {
-      observer.next(data)
-      observer.complete()
-    });
+    this.rowData$ = this.clubService.getClubs();
   }
 
   onCellClicked( e: CellClickedEvent): void {

--- a/front-end/src/app/clubs/sample-clubs.json
+++ b/front-end/src/app/clubs/sample-clubs.json
@@ -1,6 +1,0 @@
-[
-    { "name": "Firebrands", "id": "001AAA", "address": "Longwood, Clevedon Road, Failand, Bristol BS8 3TL", "shortName": "FHC", "teams": [] },
-    { "name": "Bristol City", "id": "002BBB", "address": "Ashton Rd, Bristol BS3 2EJ", "shortName": "BCFC", "teams": [] },
-    { "name": "Liverpool Football Club", "id": "003CCC", "address": "Anfield Rd, Anfield, Liverpool L4 0TH", "shortName": "LFC", "teams": [] },
-    { "name": "Beeston Hockey Club", "id": "004DDD", "address": "Highfields Park, University Blvd, Nottingham NG7 2PS", "shortName": "BHC", "teams": [] }
-]

--- a/front-end/src/app/team/team.component.html
+++ b/front-end/src/app/team/team.component.html
@@ -1,0 +1,1 @@
+<p>team works!</p>

--- a/front-end/src/app/team/team.component.spec.ts
+++ b/front-end/src/app/team/team.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TeamComponent } from './team.component';
+
+describe('TeamComponent', () => {
+  let component: TeamComponent;
+  let fixture: ComponentFixture<TeamComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TeamComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TeamComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-end/src/app/team/team.component.ts
+++ b/front-end/src/app/team/team.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-team',
+  templateUrl: './team.component.html',
+  styleUrls: ['./team.component.css']
+})
+export class TeamComponent {
+
+}

--- a/front-end/src/app/types/Club.ts
+++ b/front-end/src/app/types/Club.ts
@@ -1,0 +1,9 @@
+import { Team } from "./Team"
+
+export type Club = {
+    id: string,
+    name: string,
+    address: string,
+    shortName: string,
+    teams: Team[]
+}

--- a/front-end/src/app/types/Team.ts
+++ b/front-end/src/app/types/Team.ts
@@ -1,0 +1,7 @@
+export type Team = {
+    id: string,
+    name: string,
+    address: string,
+    shortName: string,
+    clubId: string
+}


### PR DESCRIPTION
Resolves #8 

Note: We're passing in the long name to identify the team and club. If this is unique, can we get rid of the shortname and id? If not, we'll need to edit the cell renderer to pass in the ID, or make the whole row clickable.

Future work:
- Pretty print for URL links (full name with no whitespace): https://github.com/EllieHield/GMSv2/issues/30
- Consider abstracting away grid component: https://github.com/EllieHield/GMSv2/issues/29

![image](https://user-images.githubusercontent.com/15249483/236473493-f2b4a53f-00dd-4473-bf9b-2dc43eb70c29.png)

![image](https://user-images.githubusercontent.com/15249483/236473578-6629913d-0d35-4502-be31-1a75e1a54292.png)

![image](https://user-images.githubusercontent.com/15249483/236473693-0e575619-48db-4ee5-9a85-3c0bd90d76ed.png)
