### PR TITLE
Refactor ag grid component

### DIFF
--- a/front-end/src/app/app.module.ts
+++ b/front-end/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { ClubsComponent } from './clubs/clubs.component';
 import { ClubComponent } from './club/club.component';
 import { LinkRendererComponent } from './cell-renderers/link-cell/link-cell.component';
 import { TeamComponent } from './team/team.component';
+import { GridComponent } from './grid/grid.component';
 
 @NgModule({
   declarations: [
@@ -18,7 +19,8 @@ import { TeamComponent } from './team/team.component';
     ClubsComponent,
     ClubComponent,
     LinkRendererComponent,
-    TeamComponent
+    TeamComponent,
+    GridComponent
   ],
   imports: [
     BrowserModule,

--- a/front-end/src/app/app.module.ts
+++ b/front-end/src/app/app.module.ts
@@ -1,26 +1,20 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
 
 import { AppComponent } from './app.component';
-import { AgGridModule } from 'ag-grid-angular';
 import { ClubsComponent } from './clubs/clubs.component';
 import { ClubComponent } from './club/club.component';
-import { LinkRendererComponent } from './cell-renderers/link-cell/link-cell.component';
 import { TeamComponent } from './team/team.component';
-import { GridComponent } from './grid/grid.component';
+import { GridModule } from './grid/grid.module';
 
 @NgModule({
   declarations: [
     AppComponent,
     ClubsComponent,
     ClubComponent,
-    LinkRendererComponent,
-    TeamComponent,
-    GridComponent
+    TeamComponent
   ],
   imports: [
     BrowserModule,
@@ -30,9 +24,7 @@ import { GridComponent } from './grid/grid.component';
       { path: 'clubs/:clubId', component: ClubComponent },
       { path: 'teams/:teamId', component: TeamComponent }
     ]),
-    BrowserAnimationsModule,
-    FormsModule,
-    AgGridModule,
+    GridModule
   ],
   providers: [HttpClientModule],
   bootstrap: [AppComponent]

--- a/front-end/src/app/club/club.component.html
+++ b/front-end/src/app/club/club.component.html
@@ -1,13 +1,4 @@
 <h2 *ngIf="club">
   {{club.name}}
 </h2>
-<ag-grid-angular
-   style="width: 100%; height: 100%"
-   class="ag-theme-alpine"
-   [columnDefs]="columnDefs"
-   [defaultColDef]="defaultColDef"
-   [rowData]="rowData$ | async"
-   [rowSelection]="'multiple'"
-   [animateRows]="true"
-   (gridReady)="onGridReady()"
- ></ag-grid-angular>
+<app-grid [columns]="columns" [rowData$]="rowData$"></app-grid>

--- a/front-end/src/app/club/club.component.spec.ts
+++ b/front-end/src/app/club/club.component.spec.ts
@@ -4,6 +4,7 @@ import { ClubComponent } from './club.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AgGridModule } from 'ag-grid-angular';
+import { GridComponent } from '../grid/grid.component';
 
 describe('ClubComponent', () => {
   let component: ClubComponent;
@@ -16,7 +17,7 @@ describe('ClubComponent', () => {
         RouterTestingModule,
         AgGridModule
       ],
-      declarations: [ ClubComponent ]
+      declarations: [ ClubComponent, GridComponent ]
     })
     .compileComponents();
 

--- a/front-end/src/app/club/club.component.spec.ts
+++ b/front-end/src/app/club/club.component.spec.ts
@@ -3,8 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ClubComponent } from './club.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { AgGridModule } from 'ag-grid-angular';
-import { GridComponent } from '../grid/grid.component';
+import { GridModule } from '../grid/grid.module';
 
 describe('ClubComponent', () => {
   let component: ClubComponent;
@@ -15,9 +14,11 @@ describe('ClubComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
-        AgGridModule
+        GridModule
       ],
-      declarations: [ ClubComponent, GridComponent ]
+      declarations: [
+        ClubComponent
+      ]
     })
     .compileComponents();
 

--- a/front-end/src/app/club/club.component.ts
+++ b/front-end/src/app/club/club.component.ts
@@ -8,6 +8,7 @@ import { Club } from '../types/Club';
 import { ClubService } from '../club-service/club.service';
 import { ActivatedRoute } from '@angular/router';
 import { LinkRendererComponent } from '../cell-renderers/link-cell/link-cell.component';
+import { GridColumn } from '../types/GridColumn';
 
 @Component({
   selector: 'app-club',
@@ -17,24 +18,17 @@ import { LinkRendererComponent } from '../cell-renderers/link-cell/link-cell.com
 export class ClubComponent {
   club: Club | undefined;
   teams: Team[] = [];
-  rowData$: Observable<Team[]> = of();
-  @ViewChild(AgGridAngular) agGrid!: AgGridAngular;
-
-  constructor(private clubService: ClubService, private route: ActivatedRoute) {}
-
-  columnDefs: ColDef[] = [
-    { field: 'name', cellRenderer: LinkRendererComponent, cellRendererParams: { inRouterLink: '/teams' } },
+  rowData$: Observable<Team[]> = of();  
+  columns: GridColumn[] = [
+    { field: 'name', routerLink: 'teams' },
     { field: 'league'},
     { field: 'gender' },
     { field: 'ageRange' }
   ];
 
-  defaultColDef: ColDef = {
-    sortable: true,
-    filter: true,
-  };
+  constructor(private clubService: ClubService, private route: ActivatedRoute) {}
 
-  onGridReady() {
+  ngOnInit() {
     const clubId = this.route.snapshot.paramMap.get('clubId');
     if (clubId) {
       this.clubService.getClub(clubId).subscribe(club => this.club = club);

--- a/front-end/src/app/clubs/clubs.component.html
+++ b/front-end/src/app/clubs/clubs.component.html
@@ -1,11 +1,2 @@
 <h1 class="title">Clubs</h1>
-<ag-grid-angular
-   style="width: 100%; height: 100%"
-   class="ag-theme-alpine"
-   [columnDefs]="columnDefs"
-   [defaultColDef]="defaultColDef"
-   [rowData]="rowData$ | async"
-   [rowSelection]="'multiple'"
-   [animateRows]="true"
-   (gridReady)="onGridReady($event)"
- ></ag-grid-angular>
+<app-grid [columns]="columns" [rowData$]="rowData$"></app-grid>

--- a/front-end/src/app/clubs/clubs.component.spec.ts
+++ b/front-end/src/app/clubs/clubs.component.spec.ts
@@ -1,9 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { AgGridModule } from 'ag-grid-angular';
 
 import { ClubsComponent } from './clubs.component';
-import { GridComponent } from '../grid/grid.component';
+import { GridModule } from '../grid/grid.module';
 
 
 describe('ClubsComponent', () => {
@@ -14,9 +13,11 @@ describe('ClubsComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
-        AgGridModule
+        GridModule
       ],
-      declarations: [ ClubsComponent, GridComponent ]
+      declarations: [
+        ClubsComponent
+      ]
     })
     .compileComponents();
 

--- a/front-end/src/app/clubs/clubs.component.spec.ts
+++ b/front-end/src/app/clubs/clubs.component.spec.ts
@@ -3,6 +3,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AgGridModule } from 'ag-grid-angular';
 
 import { ClubsComponent } from './clubs.component';
+import { GridComponent } from '../grid/grid.component';
 
 
 describe('ClubsComponent', () => {
@@ -15,7 +16,7 @@ describe('ClubsComponent', () => {
         HttpClientTestingModule,
         AgGridModule
       ],
-      declarations: [ ClubsComponent ]
+      declarations: [ ClubsComponent, GridComponent ]
     })
     .compileComponents();
 

--- a/front-end/src/app/clubs/clubs.component.ts
+++ b/front-end/src/app/clubs/clubs.component.ts
@@ -1,10 +1,8 @@
-import { Component, ViewChild } from '@angular/core';
-import { AgGridAngular } from 'ag-grid-angular';
-import { CellClickedEvent, ColDef, GridReadyEvent } from 'ag-grid-community';
+import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
-import { LinkRendererComponent } from '../cell-renderers/link-cell/link-cell.component';
 import { ClubService } from '../club-service/club.service';
 import { Club } from '../types/Club';
+import { GridColumn } from '../types/GridColumn';
 
 @Component({
   selector: 'app-clubs',
@@ -12,33 +10,13 @@ import { Club } from '../types/Club';
   styleUrls: ['./clubs.component.css']
 })
 export class ClubsComponent {
-  public columnDefs: ColDef[] = [
-    { field: 'name', cellRenderer: LinkRendererComponent, cellRendererParams: { inRouterLink: '/clubs' } },
+  columns: GridColumn[] = [
+    { field: 'name', routerLink: 'clubs' },
     { field: 'shortName'},
     { field: 'address'}
-  ];
+  ]
 
-  public defaultColDef: ColDef = {
-    sortable: true,
-    filter: true,
-  };
-
-  public rowData$!: Observable<Club[]>;
-
-  @ViewChild(AgGridAngular) agGrid!: AgGridAngular;
+  public rowData$: Observable<Club[]> = this.clubService.getClubs();
 
   constructor(private clubService: ClubService) {}
-
-  onGridReady(params: GridReadyEvent) {
-    this.rowData$ = this.clubService.getClubs();
-  }
-
-  onCellClicked( e: CellClickedEvent): void {
-    console.log('cellClicked', e);
-  }
-
-  clearSelection(): void {
-    this.agGrid.api.deselectAll();
-  }
-
 }

--- a/front-end/src/app/grid/grid.component.html
+++ b/front-end/src/app/grid/grid.component.html
@@ -1,0 +1,11 @@
+<ag-grid-angular
+   style="width: 100%; height: 100%"
+   class="ag-theme-alpine"
+   [columnDefs]="columnDefs"
+   [defaultColDef]="defaultColDef"
+   [rowData]="rowData$ | async"
+   [rowSelection]="'multiple'"
+   [animateRows]="true"
+   (gridReady)="onGridReady($event)"
+   (cellClicked)="onCellClicked($event)"
+ ></ag-grid-angular>

--- a/front-end/src/app/grid/grid.component.spec.ts
+++ b/front-end/src/app/grid/grid.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GridComponent } from './grid.component';
+import { AgGridModule } from 'ag-grid-angular';
+
+describe('GridComponent', () => {
+  let component: GridComponent<any>;
+  let fixture: ComponentFixture<GridComponent<any>>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        GridComponent
+      ],
+      imports: [
+        AgGridModule
+      ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(GridComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-end/src/app/grid/grid.component.ts
+++ b/front-end/src/app/grid/grid.component.ts
@@ -1,0 +1,42 @@
+import { Component, Input, ViewChild } from '@angular/core';
+import { AgGridAngular } from 'ag-grid-angular';
+import { CellClickedEvent, ColDef, GridReadyEvent } from 'ag-grid-community';
+import { Observable, of } from 'rxjs';
+import { LinkRendererComponent } from '../cell-renderers/link-cell/link-cell.component';
+import { GridColumn } from '../types/GridColumn';
+
+@Component({
+  selector: 'app-grid',
+  templateUrl: './grid.component.html',
+  styleUrls: ['./grid.component.css']
+})
+export class GridComponent<T> {
+  @Input() columns: GridColumn[] = [];
+  @Input() rowData$: Observable<T[]> = of();
+  @ViewChild(AgGridAngular) agGrid!: AgGridAngular;
+
+  constructor() {}
+
+  columnDefs: ColDef[] = [];
+
+  defaultColDef: ColDef = {
+    sortable: true,
+    filter: true,
+  };
+
+  onGridReady(params: GridReadyEvent) {
+    this.columnDefs = this.columns.map(({ field, routerLink }) => ({
+      field,
+      cellRenderer: routerLink ? LinkRendererComponent : null,
+      cellRendererParams: routerLink ? { inRouterLink: `/${routerLink}` } : null
+    }));
+  }
+
+  onCellClicked(e: CellClickedEvent): void {
+    console.log('cellClicked', e);
+  }
+
+  clearSelection(): void {
+    this.agGrid.api.deselectAll();
+  }
+}

--- a/front-end/src/app/grid/grid.module.ts
+++ b/front-end/src/app/grid/grid.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { GridComponent } from './grid.component';
+import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { AgGridModule } from 'ag-grid-angular';
+import { LinkRendererComponent } from '../cell-renderers/link-cell/link-cell.component';
+import { RouterModule } from '@angular/router';
+
+@NgModule({
+  declarations: [
+    GridComponent,
+    LinkRendererComponent
+  ],
+  imports: [
+    CommonModule,
+    BrowserAnimationsModule,
+    FormsModule,
+    AgGridModule,
+    RouterModule
+  ],
+  exports: [
+    GridComponent
+  ]
+})
+export class GridModule { }

--- a/front-end/src/app/team/team.component.html
+++ b/front-end/src/app/team/team.component.html
@@ -6,14 +6,4 @@
   <p>Age: {{team.ageRange}}</p>
   <p>Club: <a [routerLink]="['/clubs', team.clubId]">{{club.name}}</a><br></p>
 </div>
-
-<ag-grid-angular
-   style="width: 50%; height: 50%"
-   class="ag-theme-alpine"
-   [columnDefs]="columnDefs"
-   [defaultColDef]="defaultColDef"
-   [rowData]="rowData$ | async"
-   [rowSelection]="'multiple'"
-   [animateRows]="true"
-   (gridReady)="onGridReady($event)"
- ></ag-grid-angular>
+<app-grid [columns]="columns" [rowData$]="rowData$"></app-grid>

--- a/front-end/src/app/team/team.component.spec.ts
+++ b/front-end/src/app/team/team.component.spec.ts
@@ -3,6 +3,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AgGridModule } from 'ag-grid-angular';
 import { TeamComponent } from './team.component';
 import { RouterTestingModule } from '@angular/router/testing';
+import { GridComponent } from '../grid/grid.component';
 
 describe('TeamComponent', () => {
   let component: TeamComponent;
@@ -15,7 +16,7 @@ describe('TeamComponent', () => {
         RouterTestingModule,
         AgGridModule
       ],
-      declarations: [ TeamComponent ]
+      declarations: [ TeamComponent, GridComponent ]
     })
     .compileComponents();
 

--- a/front-end/src/app/team/team.component.spec.ts
+++ b/front-end/src/app/team/team.component.spec.ts
@@ -1,9 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { AgGridModule } from 'ag-grid-angular';
 import { TeamComponent } from './team.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { GridComponent } from '../grid/grid.component';
+import { GridModule } from '../grid/grid.module';
 
 describe('TeamComponent', () => {
   let component: TeamComponent;
@@ -14,9 +13,11 @@ describe('TeamComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
-        AgGridModule
+        GridModule
       ],
-      declarations: [ TeamComponent, GridComponent ]
+      declarations: [
+        TeamComponent
+      ]
     })
     .compileComponents();
 

--- a/front-end/src/app/team/team.component.ts
+++ b/front-end/src/app/team/team.component.ts
@@ -1,12 +1,11 @@
-import { Component, ViewChild } from '@angular/core';
-import { AgGridAngular } from 'ag-grid-angular';
-import { ColDef, GridReadyEvent } from 'ag-grid-community';
+import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Player } from '../types/Player';
 import { Team } from '../types/Team';
 import { ActivatedRoute } from '@angular/router';
 import { TeamService } from '../team-service/team.service';
 import { Club } from '../types/Club';
+import { GridColumn } from '../types/GridColumn';
 
 @Component({
   selector: 'app-team',
@@ -22,31 +21,20 @@ export class TeamComponent {
   team: Team | undefined;
   club: Club | undefined;
 
-  public columnDefs: ColDef[] = [
+  columns: GridColumn[] = [
     { field: 'name' },
     { field: 'email' },
     { field: 'address' },
   ];
 
-  public defaultColDef: ColDef = {
-    sortable: true,
-    filter: true,
-  };
+  rowData$!: Observable<Player[]>;
 
-  public rowData$!: Observable<Player[]>;
-
-  @ViewChild(AgGridAngular) agGrid!: AgGridAngular;
-
-  onGridReady(params: GridReadyEvent) {
+  ngOnInit() {
     const teamId = this.route.snapshot.paramMap.get('teamId');
     if (teamId) {
       this.teamService.getTeam(teamId).subscribe(team => this.team = team);
       this.teamService.getClubOfTeam(teamId).subscribe(club => this.club = club);
       this.rowData$ = this.teamService.getPlayersInTeam(teamId);
     }
-  }
-
-  clearSelection(): void {
-    this.agGrid.api.deselectAll();
   }
 }

--- a/front-end/src/app/types/GridColumn.ts
+++ b/front-end/src/app/types/GridColumn.ts
@@ -1,0 +1,4 @@
+export type GridColumn = {
+    field: string;
+    routerLink?: string;
+};


### PR DESCRIPTION
The idea is to abstract away ag-grid from the other components, because I don't like the API for ag-grid 😅 This way, we are exposing just the functionality we need, and no more. We will likely need to keep adding to this, but I hope that it will be more maintainable than if we tightly couple ourselves to ag-grid.

Resolves #29 